### PR TITLE
Support MSVC++ 12.0

### DIFF
--- a/include/dkm.hpp
+++ b/include/dkm.hpp
@@ -89,7 +89,12 @@ std::vector<std::array<T, N>> random_plusplus(const std::vector<std::array<T, N>
 		auto distances = details::closest_distance(means, data, k);
 		// Pick a random point weighted by the distance from existing means
 		// TODO: This might convert floating point weights to ints, distorting the distribution for small weights
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
 		std::discrete_distribution<input_size_t> generator(distances.begin(), distances.end());
+#else  // MSVC++ older than 14.0
+		input_size_t i = 0;
+		std::discrete_distribution<input_size_t> generator(distances.size(), 0.0, 0.0, [&distances, &i](double) { return distances[i++]; });
+#endif
 		means.push_back(data[generator(rand_engine)]);
 	}
 	return means;


### PR DESCRIPTION
Hi Nick,

I have added a simple work-around for the `std::discrete_distribution` constructor taking begin/end iterators that is missing from MSVC++ 12.0, so that `dkm.hpp` now compiles in Visual Studio 2013.

For later versions of VS/VC and other compilers the existing code path remains to be used, which works just fine.

Thanks and keep up the great work,
Steve