### PR TITLE
Travis CI update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,52 +1,38 @@
 # Use new trusty images, should yield newer compilers and packages
-sudo: required
-dist: precise
+sudo: false
+dist: trusty
 language: cpp
 
 matrix:
   include:
     - compiler: gcc
+      env: COMPILER=g++
+    - compiler: gcc 7.0
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-4.9
-      env: COMPILER=g++-4.9
-    - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-5
-      env: COMPILER=g++-5
+            - g++-7
+      env: COMPILER=g++-7
     - compiler: clang
+      env: COMPILER=clang++
+    - compiler: clang 5.0
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.6
+            - llvm-toolchain-trusty-5.0
           packages:
-            - clang-3.6
-      env: COMPILER=clang++-3.6
-    - compiler: clang
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.7
-          packages:
-            - clang-3.7
-      env: COMPILER=clang++-3.7
+            - clang-5.0
+      env: COMPILER=clang++-5.0
 
-before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -y libopencv-dev
+packages:
+  - libopencv-dev
 script:
+  - $COMPILER --version
   - mkdir build
   - cd build
-  - cmake -DCMAKE_CXX_COMPILER=$COMPILER .. && make
+  - cmake -DCMAKE_CXX_COMPILER=$COMPILER .. && make -j$(nproc --all)
   - ./dkm_tests
   - ./dkm_bench
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,37 +5,20 @@ language: cpp
 
 matrix:
   include:
-    - compiler: g++-4.9
-      addons:
-        apt:
-          sources
-            - ubuntu-toolchain-r-test:
-          packages:
-            - g++-4.9
+    - compiler: g++
     - compiler: g++-7
-      addons:
-        apt:
-          sources
-            - ubuntu-toolchain-r-test:
-          packages:
-            - g++-7
     - compiler: clang++-3.4
-      addons:
-        apt:
-          sources
-            - ubuntu-toolchain-r-test:
-            - llvm-toolchain-trusty-3.4
-          packages:
-            - clang-3.4
-    - compiler: clang++-5.0
+    - compiler: clang++
 
 packages:
   - libopencv-dev
 script:
   - $CXX --version
+  - ls /usr/share/OpenCV
+  - ls /usr/lib | grep -i opencv
   - mkdir build
   - cd build
-  - cmake -DOpenCV_DIR=/usr/share/OpenCV .. && make -j$(nproc --all)
+  - cmake .. && make -j$(nproc --all)
   - ./dkm_tests
   - ./dkm_bench
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,25 @@ language: cpp
 
 matrix:
   include:
-    - compiler: g++-4.8
+    - compiler: g++-4.9
+      addons:
+        apt:
+          sources
+            - ubuntu-toolchain-r-test:
+          packages:
+            - g++-4.9
     - compiler: g++-7
+      addons:
+        apt:
+          sources
+            - ubuntu-toolchain-r-test:
+          packages:
+            - g++-7
     - compiler: clang++-3.4
       addons:
         apt:
-          sources:
+          sources
+            - ubuntu-toolchain-r-test:
             - llvm-toolchain-trusty-3.4
           packages:
             - clang-3.4
@@ -20,6 +33,8 @@ packages:
   - libopencv-dev
 script:
   - $CXX --version
+  - ls /usr/share/OpenCV
+  - ls /usr/lib | grep -i opencv
   - mkdir build
   - cd build
   - cmake -DOpenCV_DIR=/usr/share/OpenCV .. && make -j$(nproc --all)

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - compiler: g++-4.9
       addons:
         apt:
-          sources
+          sources:
             - ubuntu-toolchain-r-test:
           packages:
             - g++-4.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,6 @@ packages:
   - libopencv-dev
 script:
   - $CXX --version
-  - ls /usr/share/OpenCV
-  - ls /usr/lib | grep -i opencv
   - mkdir build
   - cd build
   - cmake -DOpenCV_DIR=/usr/share/OpenCV .. && make -j$(nproc --all)

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,13 +46,17 @@ matrix:
     - compiler: clang++-5.0
       addons:
         apt:
+          sources:
+            - ubuntu-toolchain-r-test
           packages:
+            - clang-5.0
+            - clang++-5.0
             - gcc-4.9
             - g++-4.9
             - libopencv-dev
       env: 
-        - C_COMPILER=clang
-        - CXX_COMPILER=clang++
+        - C_COMPILER=clang-5.0
+        - CXX_COMPILER=clang++-5.0
 script:
   - $CXX_COMPILER --version
   - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,15 @@ language: cpp
 
 matrix:
   include:
-    - compiler: g++-4.9
+    - compiler: g++-4.8
     - compiler: g++-7
     - compiler: clang++-3.4
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-3.4
+          packages:
+            - clang-3.4
     - compiler: clang++-5.0
 
 packages:
@@ -16,7 +22,7 @@ script:
   - $CXX --version
   - mkdir build
   - cd build
-  - cmake .. && make -j$(nproc --all)
+  - cmake -DOpenCV_DIR=/usr/share/OpenCV .. && make -j$(nproc --all)
   - ./dkm_tests
   - ./dkm_bench
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,17 +25,16 @@ matrix:
             - g++-7
             - libopencv-dev
       env: COMPILER=g++-7
-    - compiler: clang++-3.4
+    - compiler: clang++-3.5
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-3.4
           packages:
-            - clang-3.4
-            - clang++-3.4
+            - clang-3.5
+            - clang++-3.5
             - libopencv-dev
-      env: COMPILER=clang++-3.4
+      env: COMPILER=clang++-3.5
     - compiler: clang++-5.0
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # Use new trusty images, should yield newer compilers and packages
-sudo: false
+sudo: required
 dist: trusty
 language: cpp
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,31 @@ matrix:
       addons:
         apt:
           sources:
-            - sourceline: 'ppa:ubuntu-toolchain-r/test'
+            - ubuntu-toolchain-r-test
           packages:
             - g++-4.9
+            - libopencv-dev
     - compiler: g++-7
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+            - libopencv-dev
     - compiler: clang++-3.4
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-3.4
+          packages:
+            - clang++-3.4
+            - libopencv-dev
     - compiler: clang++
-addons:
-  apt:
-    packages:
-    - libopencv-dev
+        apt:
+          packages:
+            -libopencv-dev
 script:
   - $CXX --version
   - ls /usr/share/OpenCV

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ matrix:
             - clang++-3.4
             - libopencv-dev
     - compiler: clang++
+      addons:
         apt:
           packages:
             -libopencv-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
+            - gcc-4.9
             - g++-4.9
             - libopencv-dev
     - compiler: g++-7
@@ -19,6 +20,7 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
+            - gcc-7
             - g++-7
             - libopencv-dev
     - compiler: clang++-3.4
@@ -28,17 +30,16 @@ matrix:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-trusty-3.4
           packages:
+            - clang-3.4
             - clang++-3.4
             - libopencv-dev
     - compiler: clang++
       addons:
         apt:
           packages:
-            -libopencv-dev
+            - libopencv-dev
 script:
   - $CXX --version
-  - ls /usr/share/OpenCV
-  - ls /usr/lib | grep -i opencv
   - mkdir build
   - cd build
   - cmake .. && make -j$(nproc --all)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # Use new trusty images, should yield newer compilers and packages
-sudo: required
+sudo: false
 dist: trusty
 language: cpp
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
             - gcc-4.9
             - g++-4.9
             - libopencv-dev
+      env: COMPILER=g++-4.9
     - compiler: g++-7
       addons:
         apt:
@@ -23,6 +24,7 @@ matrix:
             - gcc-7
             - g++-7
             - libopencv-dev
+      env: COMPILER=g++-7
     - compiler: clang++-3.4
       addons:
         apt:
@@ -33,16 +35,18 @@ matrix:
             - clang-3.4
             - clang++-3.4
             - libopencv-dev
-    - compiler: clang++
+      env: COMPILER=clang++-3.4
+    - compiler: clang++-5.0
       addons:
         apt:
           packages:
             - libopencv-dev
+      env: COMPILER=clang++
 script:
   - $CXX --version
   - mkdir build
   - cd build
-  - cmake .. && make -j$(nproc --all)
+  - cmake -DCMAKE_CXX_COMPILER=$COMPILER .. && make -j$(nproc --all)
   - ./dkm_tests
   - ./dkm_bench
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test:
+            - sourceline: 'ppa:ubuntu-toolchain-r/test'
           packages:
             - g++-4.9
     - compiler: g++-7

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,9 @@ matrix:
             - gcc-4.9
             - g++-4.9
             - libopencv-dev
-      env: COMPILER=g++-4.9
+      env: 
+        - C_COMPILER=gcc-4.9
+        - CXX_COMPILER=g++-4.9
     - compiler: g++-7
       addons:
         apt:
@@ -24,7 +26,9 @@ matrix:
             - gcc-7
             - g++-7
             - libopencv-dev
-      env: COMPILER=g++-7
+      env: 
+        - C_COMPILER=gcc-7
+        - CXX_COMPILER=g++-7
     - compiler: clang++-3.5
       addons:
         apt:
@@ -33,19 +37,27 @@ matrix:
           packages:
             - clang-3.5
             - clang++-3.5
+            - gcc-4.9
+            - g++-4.9
             - libopencv-dev
-      env: COMPILER=clang++-3.5
+      env: 
+        - C_COMPILER=clang-3.5
+        - CXX_COMPILER=clang++-3.5
     - compiler: clang++-5.0
       addons:
         apt:
           packages:
+            - gcc-4.9
+            - g++-4.9
             - libopencv-dev
-      env: COMPILER=clang++
+      env: 
+        - C_COMPILER=clang
+        - CXX_COMPILER=clang++
 script:
-  - $CXX --version
+  - $CXX_COMPILER --version
   - mkdir build
   - cd build
-  - cmake -DCMAKE_CXX_COMPILER=$COMPILER .. && make -j$(nproc --all)
+  - cmake -DCMAKE_CXX_COMPILER=$CXX_COMPILER -DCMAKE_C_COMPILER=$C_COMPILER .. && make -j$(nproc --all)
   - ./dkm_tests
   - ./dkm_bench
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,34 +5,18 @@ language: cpp
 
 matrix:
   include:
-    - compiler: gcc
-      env: COMPILER=g++
-    - compiler: gcc 7.0
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-7
-      env: COMPILER=g++-7
-    - compiler: clang
-      env: COMPILER=clang++
-    - compiler: clang 5.0
-      addons:
-        apt:
-          sources:
-            - llvm-toolchain-trusty-5.0
-          packages:
-            - clang-5.0
-      env: COMPILER=clang++-5.0
+    - compiler: g++-4.9
+    - compiler: g++-7
+    - compiler: clang++-3.4
+    - compiler: clang++-5.0
 
 packages:
   - libopencv-dev
 script:
-  - $COMPILER --version
+  - $CXX --version
   - mkdir build
   - cd build
-  - cmake -DCMAKE_CXX_COMPILER=$COMPILER .. && make -j$(nproc --all)
+  - cmake .. && make -j$(nproc --all)
   - ./dkm_tests
   - ./dkm_bench
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,20 @@ language: cpp
 
 matrix:
   include:
-    - compiler: g++
+    - compiler: g++-4.9
+      addons:
+        apt:
+          sources
+            - ubuntu-toolchain-r-test:
+          packages:
+            - g++-4.9
     - compiler: g++-7
     - compiler: clang++-3.4
     - compiler: clang++
-
-packages:
-  - libopencv-dev
+addons:
+  apt:
+    packages:
+    - libopencv-dev
 script:
   - $CXX --version
   - ls /usr/share/OpenCV

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-5.0
           packages:
             - clang-5.0
             - clang++-5.0

--- a/README.md
+++ b/README.md
@@ -66,12 +66,12 @@ The tests can be run using the `make test` command or executing `./dkm_tests` in
 
 The following compilers are officially supported on Linux and tested via [Travis](https://travis-ci.org/genbattle/dkm):
 
-- Clang 3.6
-- Clang 3.7
+- Clang 3.5
+- Clang 5.0
 - GCC 4.9
-- GCC 5.0+
+- GCC 7.0
 
-GCC/Clang versions prior to the above are intentionally unsupported due to poor C++11 support. Other compilers may be considered, Microsoft VC++ is intended to be supported, but does not currently have a CI build set up.
+GCC/Clang versions prior to the above are intentionally unsupported due to poor C++11 support. Other versions between or after the supported versions should work: if they don't, please create a bug report or pull request. Microsoft VC++ 12.0+ (Visual Studio 2013 or later) is intended to be supported, but does not currently have a CI build set up.
 
 ### Dependencies (test) ###
 


### PR DESCRIPTION
Travis is [beginning to phase out their precise environments](https://blog.travis-ci.com/2017-08-31-trusty-as-default-status), which I only used in the first place because Trusty was unstable when I created this project. Now that Trusty is capable of building this project it presents a more future-proof platform for CI going forward.

The only downside to this change is that build times will increase by a significant amount, but will still be around 5 minutes in total. To minimize build times in the future my plan is to use a custom docker container running on Travis' infrastructure to avoid downloading and installing so many dependencies for each build.