### PR TITLE
Fixes get_random_seed() function to return randor seed, not _has_rand_seed

### DIFF
--- a/include/dkm.hpp
+++ b/include/dkm.hpp
@@ -233,7 +233,7 @@ public:
 	uint32_t get_k() const { return _k; };
 	uint64_t get_max_iteration() const { return _max_iter; }
 	T get_min_delta() const { return _min_delta; }
-	uint64_t get_random_seed() const { return _has_rand_seed; }
+	uint64_t get_random_seed() const { return _rand_seed; }
 
 private:
 	uint32_t _k;

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -56,7 +56,7 @@ const lest::test specification[] = {
 			
 			SECTION("Initial means picked correctly") {
 				auto means = dkm::details::random_plusplus(data, parameters.get_k(), parameters.get_random_seed());
-				std::vector<std::array<float, 2>> expected_means{{14.9f, 29.114f}, {-26.608f, -23.007f}, {125.64f, 24.364f}};
+				std::vector<std::array<float, 2>> expected_means{{15.082f, 23.051f}, {133.423f, 23.644f}, {-24.734f, -3.788f}};
 				EXPECT(means.size() == 3u);
 				EXPECT(means == expected_means);
 			}
@@ -66,7 +66,7 @@ const lest::test specification[] = {
 				auto means = std::get<0>(means_clusters);
 				auto clusters = std::get<1>(means_clusters);
 				// verify results
-				std::vector<std::array<float, 2>> expected_means{{15.9984f, 23.3856f}, {-28.6281f, -11.5276f}, {134.625f, 17.6372f}};
+				std::vector<std::array<float, 2>> expected_means{{15.9984f, 23.3856f}, {134.625f, 17.6372f}, {-28.6281f, -11.5276f}};
 				EXPECT(means.size() == 3u);
 				for (size_t i = 0; i < means.size(); ++i) {
 					for (size_t j = 0; j < means[i].size(); ++j) {

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -73,7 +73,7 @@ const lest::test specification[] = {
 						EXPECT(means[i][j] == lest::approx(expected_means[i][j]));
 					}
 				}
-				std::vector<uint32_t> expected_clusters = { 0, 1, 1, 1, 2, 2, 2, 0, 0, 1, 1, 1, 1, 2, 0, 0, 2};
+				std::vector<uint32_t> expected_clusters = { 0, 2, 2, 2, 1, 1, 1, 0, 0, 2, 2, 2, 2, 1, 0, 0, 1};
 				EXPECT(clusters.size() == data.size());
 				EXPECT(clusters == expected_clusters);
 			}
@@ -85,14 +85,14 @@ const lest::test specification[] = {
 				// verify results
 				EXPECT(means.size() == 3u);
 				EXPECT(clusters.size() == data.size());
-				std::vector<std::array<float, 2>> expected_means{{15.9984f, 23.3856f}, {-28.6281f, -11.5276f}, {134.625f, 17.6372f}};
+				std::vector<std::array<float, 2>> expected_means{{15.9984f, 23.3856f}, {134.625f, 17.6372f}, {-28.6281f, -11.5276f}};
 				EXPECT(means.size() == 3u);
 				for (size_t i = 0; i < means.size(); ++i) {
 					for (size_t j = 0; j < means[i].size(); ++j) {
 						EXPECT(means[i][j] == lest::approx(expected_means[i][j]));
 					}
 				}
-				std::vector<uint32_t> expected_clusters = { 0, 1, 1, 1, 2, 2, 2, 0, 0, 1, 1, 1, 1, 2, 0, 0, 2};
+				std::vector<uint32_t> expected_clusters = { 0, 2, 2, 2, 1, 1, 1, 0, 0, 2, 2, 2, 2, 1, 0, 0, 1};
 				EXPECT(clusters.size() == data.size());
 				EXPECT(clusters == expected_clusters);
 			}


### PR DESCRIPTION
get_random_seed() returned bool _has_rand_seed casted to uint64_t, which led to STL assertion with "invalid random seed" when compiled with MSVC in debug mode.