### PR TITLE
Add dynamic matrix

### DIFF
--- a/include/dkm_matrix.hpp
+++ b/include/dkm_matrix.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#ifndef DKM_MATRIX_HPP
+#define DKM_MATRIX_HPP
+
+#include <vector>
+#include <cassert>
+#include <algorithm>
+
+namespace dkm
+{
+// This class is only an interface! Not designed to be used outside library internals.
+
+template<typename T>
+class as_matrix
+{
+    const T *data = nullptr;
+
+    // column major indexer
+    auto cm_indexer(size_t i, size_t j) const -> const T&
+    {
+        assert(i >= 0 && j >= 0 && i < n_rows && j < n_cols);
+        return data[j * n_rows + i];
+    }
+
+     // row major indexer
+    auto rm_indexer(size_t i, size_t j) const -> const T&
+    {
+        assert(i >= 0 && j >= 0 && i < n_rows && j < n_cols);
+        return data[i * n_cols + j];
+    }
+
+    const T& (as_matrix<T>::*indexer) (size_t, size_t) const = nullptr;
+
+public:
+    const size_t n_rows, n_cols;
+
+    as_matrix(const T *data, size_t n_rows, size_t n_cols, bool col_major = true)
+        : data(data), n_rows(n_rows), n_cols(n_cols),
+          indexer((col_major)? &as_matrix<T>::cm_indexer: &as_matrix<T>::rm_indexer)
+    {}
+
+    auto row(size_t i) const -> std::vector<T>;
+    auto operator()(size_t i, size_t j) const -> const T&
+    {
+        return ((this)->*(this->indexer))(i, j);
+    }
+};
+
+
+template<typename T>
+auto as_matrix<T>::row(size_t i) const -> std::vector<T>
+{
+    auto res = std::vector<T>(n_cols);
+    for(size_t j = 0; j < n_cols; j++)
+    {
+        res[j] = (*this)(i, j);
+    }
+    return res;
+}
+
+}
+#endif


### PR DESCRIPTION
Instead of passing `std::vector<std::array<T, N>>` I added a new class `as_matrix` that allow passing data with size defined at runtime. The class is only an interface and all operations are read only.

For example, if the user has the data stored in `std::vector<std::pair<float, float>>`, we can easily pass it without having to copy to a new container:
```
auto matrix = dkm::as_matrix(reinterpret_cast<float*>(data.data()), data.size(), 2, false);
auto res = km::kmeans_lloyd(matrix, k);
```

Or if the data is an armadillo matrix (Eigen, etc) it is even easier:
```
auto matrix = dkm::as_matrix(data.memptr(), data.n_rows, data.n_cols);
auto res = km::kmeans_lloyd(matrix, k);
```

I think this approach is much better than the current one. For now, I only added the class and changed `dkm.hpp` (since I don't know if this will get merged and this is the only relevant part for me). One performance issue we have is `as_matrix::row` returning by value, but this can be easily fixed.