### PR TITLE
Avoid asking for a discrete_distribution when all weights are zero

### DIFF
--- a/include/dkm.hpp
+++ b/include/dkm.hpp
@@ -87,6 +87,13 @@ std::vector<std::array<T, N>> random_plusplus(const std::vector<std::array<T, N>
 		// Calculate the distance to the closest mean for each data point
 		auto distances = details::closest_distance(means, data);
 		// Pick a random point weighted by the distance from existing means
+		// If all distances are 0, the normalization step in std::discrete_distribution can cause a floating point
+		// exception, thus we check that:
+		double distance_sum = std::accumulate(distances.begin(), distances.end(), 0.0);
+		if (FP_ZERO == std::fpclassify(distance_sum)) {
+			// all distances zero, thus we want just a distribution with equal probability for everything
+			std::fill(distances.begin(), distances.end(), 1.0);
+		}
 		// TODO: This might convert floating point weights to ints, distorting the distribution for small weights
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
 		std::discrete_distribution<input_size_t> generator(distances.begin(), distances.end());


### PR DESCRIPTION
I have the case that I sometimes ask for k-means when all input points are identical.
Then all distances are zero and thus `std::discrete_distribution` is called with weight vector containing only zeros.
On my platform, that results in a floating-point exception.

This could probably also fix 